### PR TITLE
fix bug in tree.rs

### DIFF
--- a/grammartec/src/tree.rs
+++ b/grammartec/src/tree.rs
@@ -242,7 +242,7 @@ impl Tree {
             sizes,
             paren,
         };
-        if res.rules.is_empty() {
+        if !res.rules.is_empty() {
             res.calc_subtree_sizes_and_parents(ctx);
         }
         res


### PR DESCRIPTION
this bug was introduced in fcdf89d7d60b37f6d5fc69f7ad458df42aac8579 and is causing libafl based fuzzers using nautilus to crash.