### PR TITLE
fix typo in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -74,7 +74,7 @@ ctx.regex("TAG","[a-z]+")
 To test your grammars you can use the generator:
 
 ```
-$ cargo run --bin generator -- -g grammars/grammar_py_exmaple.py -t 100 
+$ cargo run --bin generator -- -g grammars/grammar_py_example.py -t 100 
 <document><some_tag foo=bar><other_tag foo=bar><other_tag foo=bar><some_tag foo=bar></some_tag></other_tag><some_tag foo=bar><other_tag foo=bar></other_tag></some_tag><other_tag foo=bar></other_tag><some_tag foo=bar></some_tag></other_tag><other_tag foo=bar></other_tag><some_tag foo=bar></some_tag></some_tag></document>
 ```
 


### PR DESCRIPTION
I fixed a typo so that running `generator` will point at the correct grammar file.